### PR TITLE
fix the error caused by different versions of c++

### DIFF
--- a/src/integrators/orbifold_path/orbifold.h
+++ b/src/integrators/orbifold_path/orbifold.h
@@ -24,12 +24,13 @@ struct OrbifoldData {
         m_numKernelTiles(1),
         m_type(OrbifoldType::OT_NONE),
         attenuate_callback(&OrbifoldData::attenuateTrivial),
-        collapse_callback(&OrbifoldData::collapseTrivial) {}
+        collapse_callback(&OrbifoldData::collapseTrivial),
+        m_incompletenessMode(false) {}
 
     ///
     /// \brief m_incompletenessMode
     /// Whether or not we are rendering an incompleteness image
-    bool m_incompletenessMode = false;
+    bool m_incompletenessMode;
 
     ///
     /// A scaling factor for the scense


### PR DESCRIPTION
Since the gcc in cluster is version 4.4 and using a old version of c++, it doesn't allow initialization inside class. I moved the initialization of "m_incompletenessMode" to the constructor.